### PR TITLE
Fix code length bug

### DIFF
--- a/betteralts-bukkit/src/main/java/com/civclassic/betteralts/BetterAltsBukkit.java
+++ b/betteralts-bukkit/src/main/java/com/civclassic/betteralts/BetterAltsBukkit.java
@@ -231,6 +231,7 @@ public class BetterAltsBukkit extends JavaPlugin {
 	private String generateLoginCode() {
 		String code = "";
 		do {
+			code = "";
 			for(int i = 0; i < 8; i++) {
 				code += alphabet[rng.nextInt(alphabet.length)];
 			}


### PR DESCRIPTION
On collision, the code would get 8 more characters added to it, but now it gets reset before that happens.